### PR TITLE
better links, some updated docs

### DIFF
--- a/BEGINNERS.md
+++ b/BEGINNERS.md
@@ -51,7 +51,7 @@ If you are on a system that does not package git yet, you may choose to
 
 To get a quick virtual machine with the core dependencies for snowdrift,
 follow the [Vagrant setup instructions](SETUP_VAGRANT.md).
-**This is the best and easiest option for all systems including
+**This is the easiest beginner's option for all systems including
 GNU/Linux, BSD, Mac OS X, and Windows.**
 
 As an alternative option, we also have instructions for local installation.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -116,9 +116,9 @@ distros of GNU/Linux and should work on all other distros as well.
 
 For NixOS, see the notes in the appendix here.
 
-Snowdrift also has been built on Mac OS Yosemite.
-The Mac OS build process seems to have some issues with postgres user names;
-so for now, the database set-up for Mac OS will need to be done manually.
+Snowdrift also has been built on OS X Yosemite.
+The OS X build process seems to have some issues with postgres user names;
+so for now, the database set-up will need to be done manually.
 See the appendix at the end of this file for more.
 
 
@@ -144,9 +144,16 @@ ghc, cabal, postgresql, and git.
 
 Various systems may need some libraries and other dependencies.
 
-**<https://www.haskell.org/downloads/linux>** has instructions for
+* **<https://www.haskell.org/downloads/linux>** has instructions for
 installing ghc, cabal, happy, and alex on Ubuntu, Fedora, and Arch,
-along with manual install instructions for other systems.
+along with manual install instructions for other Linux systems.
+
+* For OS X, see <https://ghcformacosx.github.io/>
+
+* For Windows, see <https://github.com/fpco/minghc#readme>
+  (please tell us if you successfully build directly on Windows,
+  we have no reports of that so far; we know that Windows users can
+  work with the Vagrant option linked above.)
 
 After installing the core dependencies, you should update cabal's package list:
 
@@ -158,7 +165,7 @@ Below are the most common situations:
 * for GNU/Linux, add `export PATH=$PATH:$HOME/cabal/bin:.cabal-sandbox/bin`
   to your ~/.bashrc (or equivalent) file
 
-* for Mac OS, try adding `export PATH="$HOME/Library/Haskell/bin:$PATH"`
+* for OS X, try adding `export PATH="$HOME/Library/Haskell/bin:$PATH"`
   to ~/.bash_profile
 
 (You will need to also run the line in your terminal or start a new terminal
@@ -390,7 +397,7 @@ We're not sure each of these commands is best,
 it may change as we continue testing.
 
 To install Nix, visit [NixOS.org/nix](https://nixos.org/nix/)
-and follow the "Get Nix" instructions (works for GNU/Linux and Mac OS).
+and follow the "Get Nix" instructions (works for GNU/Linux and OS X).
 
 *Note: Nix can take a lot of drive space, so if you do not have many GB
 of free space on your root partition, you may need to find another approach.
@@ -476,7 +483,7 @@ The commands below are written with GNU/Linux in mind.
 
 ***
 
-Notes for Mac OS X
+Notes for OS X
 ------------------
 
 Assuming the postgres server is running,
@@ -485,7 +492,7 @@ run `psql postgres` instead.
 The commands that don't use psql can be adapted
 to run within the psql command line.
 
-For Mac OS, instead of `sudo -u postgres psql snowdrift_development <devDB.sql`
+For OS X, instead of `sudo -u postgres psql snowdrift_development <devDB.sql`
 follow these steps:
 
 1) Run `psql snowdrift_development`

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -145,8 +145,8 @@ ghc, cabal, postgresql, and git.
 Various systems may need some libraries and other dependencies.
 
 * **<https://www.haskell.org/downloads/linux>** has instructions for
-installing ghc, cabal, happy, and alex on Ubuntu, Fedora, and Arch,
-along with manual install instructions for other Linux systems.
+  installing ghc, cabal, happy, and alex on Ubuntu, Fedora, and Arch,
+  along with manual install instructions for other Linux systems.
 
 * For OS X, see <https://ghcformacosx.github.io/>
 


### PR DESCRIPTION
I basically think this should go to main master mostly… but, these links now mix instructions for GHC 7.8 vs 7.10.

I think this should go ahead and be merged into your master in the 7.10 transition process. However, we need to update or change the GUIDE links regarding Linux and clarify 7.10 as the desired version in the GUIDE.

Anyway, I think this is good to go for now, and we'll need to scrub a little further and test everything and update Vagrant to 7.10 before we consider the transition complete and pull to master.